### PR TITLE
Hot Fix

### DIFF
--- a/AutoPartsAPI/Program.cs
+++ b/AutoPartsAPI/Program.cs
@@ -13,8 +13,11 @@ namespace AutoPartsAPI
 
             var app = builder.Build();
 
+            if (app.Environment.IsDevelopment())
+            {
                 app.UseSwagger();
                 app.UseSwaggerUI();
+            }
 
             // Configure the HTTP request pipeline.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Swagger API documentation is now restricted to development environments only, preventing unnecessary exposure in production while maintaining developer accessibility during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->